### PR TITLE
Fix project description typo

### DIFF
--- a/project02.html
+++ b/project02.html
@@ -28,7 +28,7 @@
 					<div class="inner">
 						<h1 class="major">Map Your City(MYC) Campaign</h1>
 
-						<h3>Porject Description</h3>
+						<h3>Project Description</h3>
 						<blockquote style="text-align: justify;">The "Map Your City" (MYC) campaign empowers our community of drivers and bikers to shape the future of our map data in key cities across Myanmar, including Yangon, Mandalay, Naypyidaw, Pathein, and Mawlamyine.  By using the Grab app, participants can easily add new points of interest, update existing information, and verify the accuracy of map data.  We value these contributions and offer bi-monthly monetary incentives, conveniently paid out to participants' Driver Cash Wallets.  A leaderboard adds an element of friendly competition, while a step-by-step submission process ensures a seamless experience.  The result is a continually improving map that benefits both drivers and passengers, making their journeys smoother and more efficient.</blockquote>
 
 						<h3>Objectives</h3>


### PR DESCRIPTION
## Summary
- correct a typo in `project02.html`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a6d86b630832d9d5ef6cf616182b3